### PR TITLE
Consul::Meta: not all headers are required

### DIFF
--- a/lib/Consul.pm
+++ b/lib/Consul.pm
@@ -184,8 +184,8 @@ use Moo;
 use Types::Standard qw(Int Bool);
 
 has index        => ( is => 'ro', isa => Int,  init_arg => 'x-consul-index',       required => 1 );
-has last_contact => ( is => 'ro', isa => Int,  init_arg => 'x-consul-lastcontact', required => 1 );
-has known_leader => ( is => 'ro', isa => Bool, init_arg => 'x-consul-knownleader', required => 1, coerce => sub { my $r = { true => 1, false => 0 }->{$_[0]}; defined $r ? $r : $_[0] } );
+has last_contact => ( is => 'ro', isa => Int,  init_arg => 'x-consul-lastcontact' );
+has known_leader => ( is => 'ro', isa => Bool, init_arg => 'x-consul-knownleader', coerce => sub { my $r = { true => 1, false => 0 }->{$_[0]}; defined $r ? $r : $_[0] } );
 
 
 1;


### PR DESCRIPTION
Per the API docs at https://www.consul.io/api/index.html (under
"Blocking Queries"), methods that support blocking queries only return
an X-Consul-Index header. I wanted to use this to set up a watch, but
Consul::Meta was returning undef because both lastcontact and
knownleader are required.